### PR TITLE
Fix NPE for lowercase ticket IDs in branch names

### DIFF
--- a/src/main/java/io/crowdcode/bgav/MavenHandler.java
+++ b/src/main/java/io/crowdcode/bgav/MavenHandler.java
@@ -374,7 +374,8 @@ public class MavenHandler {
     }
 
     private String extractTicketId(String version) {
-        return getMatchFirst(version, "(\\p{Upper}{1,}-\\d{1,})");
+        String ticketId = getMatchFirst(version, "(?i)(\\p{Alpha}{1,}-\\d{1,})");
+        return ticketId != null ? ticketId.toUpperCase() : null;
     }
 
 

--- a/src/main/java/io/crowdcode/bgav/Plugin.java
+++ b/src/main/java/io/crowdcode/bgav/Plugin.java
@@ -135,7 +135,7 @@ public class Plugin extends AbstractMojo {
     /**
      * default RegEx for ticket id
      */
-    private final String REGEX_TICKET = "(\\p{Upper}{1,}-\\d{1,})";
+    private final String REGEX_TICKET = "(?i)(\\p{Alpha}{1,}-\\d{1,})";
 
     @Parameter( defaultValue = "${settings}", readonly = true )
     private Settings settings;
@@ -255,10 +255,18 @@ public class Plugin extends AbstractMojo {
                     pomTicketId = getMatchFirst(parentVersion, regexTicket);;
                 }
                 ticketId = getMatchFirst(branch, regexTicket);
+                if (ticketId != null) {
+                    ticketId = ticketId.toUpperCase();
+                }
+                if (pomTicketId != null) {
+                    pomTicketId = pomTicketId.toUpperCase();
+                }
 
                 log.debug("POM ticketId: " + pomTicketId);
                 log.debug("ticketId: " + ticketId);
-                if (versionMustBeRegarded) {
+                if (ticketId == null) {
+                    log.warn("Could not extract ticket ID from branch '" + branch + "' using regex: " + regexTicket);
+                } else if (versionMustBeRegarded) {
                     // NCX-16 write new verion to POM
                     if (new XMLHandler(log, suppressCommit, suppressPush, mavenHandler).setBgavOnVersion(pomfile, ticketId)) {
                         gitHandler.add(git, ticketId + " - BGAV - set correct branched version", pomfile);
@@ -280,23 +288,25 @@ public class Plugin extends AbstractMojo {
                     throw new MojoExecutionException("mismatch Git branch ticket ID and POM branch version ticket ID");
                 }
 
-                if (parentMustBeRegarded && artifactMap.containsKey(model.getParent().getId())) {
-                    // HIER
-                    if (new XMLHandler(log, suppressCommit, suppressPush, mavenHandler).setBgavOnParentVersion(pomfile, ticketId)) {
-                        gitHandler.add(git, ticketId + " - BGAV - set correct branched version", pomfile);
-                        gottaPush = true;
+                if (ticketId != null) {
+                    if (parentMustBeRegarded && artifactMap.containsKey(model.getParent().getId())) {
+                        // HIER
+                        if (new XMLHandler(log, suppressCommit, suppressPush, mavenHandler).setBgavOnParentVersion(pomfile, ticketId)) {
+                            gitHandler.add(git, ticketId + " - BGAV - set correct branched version", pomfile);
+                            gottaPush = true;
+                        }
                     }
-                }
 
-                // NCX-36 check for affected GroupIds in dependencies
-                try {
-                    String artifacts = mavenHandler.checkforDependencies(pomfile, model, namespace, ticketId, gituser, gitpassword, settings.getLocalRepository());
-                    if (!artifacts.isEmpty()) {
-                        gitHandler.add(git, ticketId + " - BGAV - set correct branched version for " + (artifacts.endsWith(", ") ? artifacts.substring(0, artifacts.length() - 2) : artifacts),pomfile);
-                        gottaPush=true;
+                    // NCX-36 check for affected GroupIds in dependencies
+                    try {
+                        String artifacts = mavenHandler.checkforDependencies(pomfile, model, namespace, ticketId, gituser, gitpassword, settings.getLocalRepository());
+                        if (!artifacts.isEmpty()) {
+                            gitHandler.add(git, ticketId + " - BGAV - set correct branched version for " + (artifacts.endsWith(", ") ? artifacts.substring(0, artifacts.length() - 2) : artifacts),pomfile);
+                            gottaPush=true;
+                        }
+                    } catch (Exception ex) {
+                        throw new MojoExecutionException("could not check for dependencies: " + ex);
                     }
-                } catch (Exception ex) {
-                    throw new MojoExecutionException("could not check for dependencies: " + ex);
                 }
             } else if (checkForAllowedNonBgavBranch(branch)) {
                 log.debug("running non BGAV branch");

--- a/src/test/java/io/crowdcode/bgav/PluginTest.java
+++ b/src/test/java/io/crowdcode/bgav/PluginTest.java
@@ -85,6 +85,24 @@ public class PluginTest {
     }
 
     @Test
+    public void testExtractTicketIdFromLowercaseBranch() {
+        Plugin plugin = new Plugin();
+        // lowercase branch names should match and return uppercase ticket ID
+        String ticketId = plugin.getMatchFirst("feature/ncxrs-200WP02-domain-model", "(?i)(\\p{Alpha}{1,}-\\d{1,})");
+        assertNotNull("Ticket ID should be extracted from lowercase branch name", ticketId);
+        assertEquals("NCXRS-200", ticketId.toUpperCase());
+    }
+
+    @Test
+    public void testExtractTicketIdFromUppercaseBranch() {
+        Plugin plugin = new Plugin();
+        // uppercase branch names should still work
+        String ticketId = plugin.getMatchFirst("feature/NCXRS-200WP02-domain-model", "(?i)(\\p{Alpha}{1,}-\\d{1,})");
+        assertNotNull("Ticket ID should be extracted from uppercase branch name", ticketId);
+        assertEquals("NCXRS-200", ticketId.toUpperCase());
+    }
+
+    @Test
     public void testRemovePomVerion() {
         Plugin plugin = new Plugin();
         MavenHandler mavenHandler = new MavenHandler(plugin.getLog(), false, suppressPush, baseDir, null, null, null, null, pomFile);


### PR DESCRIPTION
## Summary
- Ticket ID regex now matches case-insensitively (`\p{Upper}` → `(?i)\p{Alpha}`) so branches like `feature/ncxrs-200WP02-domain-model` are supported
- Extracted ticket IDs are normalized to uppercase (e.g. `ncxrs-200` → `NCXRS-200`) for consistent version strings
- Added null-guard for `ticketId` to prevent `NullPointerException` with a clear warning log instead

## Test plan
- [x] Existing tests pass (12/12)
- [x] New test: lowercase branch name `feature/ncxrs-200WP02-domain-model` extracts `NCXRS-200`
- [x] New test: uppercase branch name `feature/NCXRS-200WP02-domain-model` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)